### PR TITLE
Fix tag pattern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ configurations {
 
 version = {
     def vd = versionDetails()
-    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v?[0-9]+\.[0-9]+\.[0-9]+(\.[a-zA-Z0-9]+)?/) {
+    if (vd.commitDistance == 0 && vd.lastTag ==~ /^v?[0-9]+\.[0-9]+\.[0-9]+([.-][a-zA-Z0-9.-]+)?/) {
         vd.lastTag
     } else {
         "0.0.0.${vd.gitHash}"


### PR DESCRIPTION
The following are valid tag patterns.
- `1.2.3`
- `v1.2.3`
- `v1.2.3.abcde.1.2.3`
- `v1.2.3-abcde-1.2.3`