### PR TITLE
bump aws-java-sdk-logs to 1.11.1034

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,8 @@ dependencies {
 
     implementation "org.embulk:embulk-util-config:0.3.4"
     implementation "com.google.guava:guava:28.2-jre"
-    implementation "com.amazonaws:aws-java-sdk-logs:1.11.749"
-    implementation "com.amazonaws:aws-java-sdk-sts:1.11.749"
+    implementation "com.amazonaws:aws-java-sdk-logs:1.11.1034"
+    implementation "com.amazonaws:aws-java-sdk-sts:1.11.1034"
 
     testImplementation "junit:junit:4.+"
     testImplementation "org.mockito:mockito-core:1.+"

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.amazonaws:aws-java-sdk-core:1.11.749=compileClasspath,runtimeClasspath
-com.amazonaws:aws-java-sdk-logs:1.11.749=compileClasspath,runtimeClasspath
-com.amazonaws:aws-java-sdk-sts:1.11.749=compileClasspath,runtimeClasspath
-com.amazonaws:jmespath-java:1.11.749=compileClasspath,runtimeClasspath
+com.amazonaws:aws-java-sdk-core:1.11.1034=compileClasspath,runtimeClasspath
+com.amazonaws:aws-java-sdk-logs:1.11.1034=compileClasspath,runtimeClasspath
+com.amazonaws:aws-java-sdk-sts:1.11.1034=compileClasspath,runtimeClasspath
+com.amazonaws:jmespath-java:1.11.1034=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.6.7=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.6.7.5=compileClasspath,runtimeClasspath
@@ -16,12 +16,12 @@ com.google.guava:failureaccess:1.0.1=compileClasspath,runtimeClasspath
 com.google.guava:guava:28.2-jre=compileClasspath,runtimeClasspath
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava=compileClasspath,runtimeClasspath
 com.google.j2objc:j2objc-annotations:1.3=compileClasspath,runtimeClasspath
-commons-codec:commons-codec:1.11=compileClasspath,runtimeClasspath
+commons-codec:commons-codec:1.15=compileClasspath,runtimeClasspath
 commons-logging:commons-logging:1.2=compileClasspath,runtimeClasspath
 javax.validation:validation-api:1.1.0.Final=compileClasspath,runtimeClasspath
 joda-time:joda-time:2.8.1=compileClasspath,runtimeClasspath
-org.apache.httpcomponents:httpclient:4.5.9=compileClasspath,runtimeClasspath
-org.apache.httpcomponents:httpcore:4.4.11=compileClasspath,runtimeClasspath
+org.apache.httpcomponents:httpclient:4.5.13=compileClasspath,runtimeClasspath
+org.apache.httpcomponents:httpcore:4.4.13=compileClasspath,runtimeClasspath
 org.checkerframework:checker-qual:2.10.0=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.embulk:embulk-util-config:0.3.4=compileClasspath,runtimeClasspath


### PR DESCRIPTION
bump aws-java-sdk-logs to the latest version of 1.11.* (1.11.1034)

Rarely it happens error: `Unable to execute HTTP request: The target server failed to respond`, so I updated aws-java-sdk-logs to confirm whether it will get better.
