### PR TITLE
set connection TTL 

### DIFF
--- a/src/main/java/org/embulk/input/cloudwatch_logs/AbstractCloudwatchLogsInputPlugin.java
+++ b/src/main/java/org/embulk/input/cloudwatch_logs/AbstractCloudwatchLogsInputPlugin.java
@@ -225,6 +225,7 @@ public abstract class AbstractCloudwatchLogsInputPlugin
 //        clientConfig.setMaxErrorRetry(3); // SDK default: 3
         clientConfig.setSocketTimeout(8 * 60 * 1000); // SDK default: 50*1000
         clientConfig.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
+        clientConfig.setConnectionTTL(30 * 1000); // default: -1
         // TODO: implement http proxy
 
         return clientConfig;


### PR DESCRIPTION
Rarely, error "The target server failed to respond" happens.
If a disconnected connection (in connection pool) is reused, this error happens.

So I fixed it to set connection TTL. (default value is -1 and it means connections do not expire)

ref: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html#setConnectionTTL-long-
