### PR TITLE
support-stop-when-file-not-found 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
     1. "profile"
     1. "instance"
 
+- **stop_when_file_not_found**: if true, check existence of files (boolean, default false)
+
 ## Example
 
 ```yaml

--- a/src/main/java/org/embulk/input/cloudwatch_logs/AbstractCloudwatchLogsInputPlugin.java
+++ b/src/main/java/org/embulk/input/cloudwatch_logs/AbstractCloudwatchLogsInputPlugin.java
@@ -168,7 +168,7 @@ public abstract class AbstractCloudwatchLogsInputPlugin
         }
 
         if (totalRecords == 0 && task.getStopWhenFileNotFound()) {
-            throw new ConfigException("\"stop_when_file_not_found\" is true, but no log records were found.");
+            throw new ConfigException("No log record is found. \"stop_when_file_not_found\" option is \"true\".");
         }
 
         return CONFIG_MAPPER_FACTORY.newTaskReport();


### PR DESCRIPTION
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/15720  
- Support `stop_when_file_not_found` option.  
  When set to `true`, the plugin checks for the existence of all files and stops if any are missing.  
  (Type: boolean, default: `false`)
